### PR TITLE
Integrate torrent playback with stats overlay

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,9 @@ dependencies {
     implementation "com.google.android.exoplayer:exoplayer-ui:$exoplayer_version"
     implementation "com.google.android.exoplayer:exoplayer-hls:$exoplayer_version"
     implementation "com.google.android.exoplayer:exoplayer-dash:$exoplayer_version"
+
+    // Torrent streaming
+    implementation 'com.github.TorrentStream:TorrentStream-Android:2.7.0'
     
     // Security
     implementation "androidx.security:security-crypto:$security_crypto_version"

--- a/app/src/main/java/com/secureiptv/player/MainActivity.kt
+++ b/app/src/main/java/com/secureiptv/player/MainActivity.kt
@@ -65,20 +65,26 @@ fun IPTVApp() {
                         popUpTo("main") { inclusive = true }
                     }
                 },
-                onNavigateToPlayer = { streamUrl, title ->
+                onNavigateToPlayer = { streamUrl, torrentUrl, title ->
                     val encodedUrl = URLEncoder.encode(streamUrl, StandardCharsets.UTF_8.toString())
                     val encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8.toString())
-                    navController.navigate("player/$encodedUrl/$encodedTitle")
+                    val encodedTorrent = URLEncoder.encode(torrentUrl ?: "", StandardCharsets.UTF_8.toString())
+                    navController.navigate("player?streamUrl=$encodedUrl&title=$encodedTitle&torrentUrl=$encodedTorrent")
                 },
                 viewModel = mainViewModel
             )
         }
-        
+
         composable(
-            "player/{streamUrl}/{title}",
+            "player?streamUrl={streamUrl}&title={title}&torrentUrl={torrentUrl}",
             arguments = listOf(
                 navArgument("streamUrl") { type = NavType.StringType },
-                navArgument("title") { type = NavType.StringType }
+                navArgument("title") { type = NavType.StringType },
+                navArgument("torrentUrl") {
+                    type = NavType.StringType
+                    defaultValue = ""
+                    nullable = true
+                }
             )
         ) { backStackEntry ->
             val streamUrl = java.net.URLDecoder.decode(
@@ -89,9 +95,15 @@ fun IPTVApp() {
                 backStackEntry.arguments?.getString("title") ?: "",
                 StandardCharsets.UTF_8.toString()
             )
-            
+            val torrentUrlArg = backStackEntry.arguments?.getString("torrentUrl")
+            val torrentUrl = torrentUrlArg?.let {
+                val decoded = java.net.URLDecoder.decode(it, StandardCharsets.UTF_8.toString())
+                if (decoded.isBlank()) null else decoded
+            }
+
             PlayerScreen(
                 streamUrl = streamUrl,
+                torrentUrl = torrentUrl,
                 title = title,
                 onBackClick = {
                     navController.popBackStack()

--- a/app/src/main/java/com/secureiptv/player/data/models/StreamSource.kt
+++ b/app/src/main/java/com/secureiptv/player/data/models/StreamSource.kt
@@ -1,0 +1,11 @@
+package com.secureiptv.player.data.models
+
+/**
+ * Represents the possible playback sources for a stream.
+ * [httpUrl] is always populated and points to the proxy HTTP endpoint.
+ * [torrentUrl] is optional and contains a magnet link or torrent URL when available.
+ */
+data class StreamSource(
+    val httpUrl: String,
+    val torrentUrl: String?
+)

--- a/app/src/main/java/com/secureiptv/player/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/secureiptv/player/ui/screens/MainScreen.kt
@@ -20,7 +20,7 @@ import com.secureiptv.player.ui.viewmodels.MainViewModel
 @Composable
 fun MainScreen(
     onLogout: () -> Unit,
-    onNavigateToPlayer: (String, String) -> Unit,
+    onNavigateToPlayer: (String, String?, String) -> Unit,
     viewModel: MainViewModel = viewModel()
 ) {
     var selectedTab by remember { mutableStateOf(0) }
@@ -63,22 +63,22 @@ fun MainScreen(
                 0 -> LiveTVScreen(
                     viewModel = viewModel,
                     onStreamClick = { stream ->
-                        val streamUrl = viewModel.getLiveStreamUrl(stream.streamId)
-                        onNavigateToPlayer(streamUrl, stream.name)
+                        val streamSource = viewModel.getLiveStreamSource(stream)
+                        onNavigateToPlayer(streamSource.httpUrl, streamSource.torrentUrl, stream.name)
                     }
                 )
                 1 -> MoviesScreen(
                     viewModel = viewModel,
                     onMovieClick = { movie ->
-                        val streamUrl = viewModel.getVodStreamUrl(movie.streamId)
-                        onNavigateToPlayer(streamUrl, movie.name)
+                        val streamSource = viewModel.getVodStreamSource(movie)
+                        onNavigateToPlayer(streamSource.httpUrl, streamSource.torrentUrl, movie.name)
                     }
                 )
                 2 -> SeriesScreen(
                     viewModel = viewModel,
                     onEpisodeClick = { episode ->
-                        val streamUrl = viewModel.getSeriesStreamUrl(episode.id)
-                        onNavigateToPlayer(streamUrl, episode.title)
+                        val streamSource = viewModel.getSeriesStreamSource(episode)
+                        onNavigateToPlayer(streamSource.httpUrl, streamSource.torrentUrl, episode.title)
                     }
                 )
                 3 -> FavoritesScreen(
@@ -89,7 +89,7 @@ fun MainScreen(
                             MainViewModel.ItemType.VOD -> viewModel.getVodStreamUrl(item.streamId)
                             MainViewModel.ItemType.SERIES -> viewModel.getSeriesStreamUrl(item.streamId)
                         }
-                        onNavigateToPlayer(streamUrl, item.title)
+                        onNavigateToPlayer(streamUrl, null, item.title)
                     }
                 )
             }

--- a/app/src/main/java/com/secureiptv/player/ui/screens/PlayerScreen.kt
+++ b/app/src/main/java/com/secureiptv/player/ui/screens/PlayerScreen.kt
@@ -26,6 +26,7 @@ import com.secureiptv.player.ui.viewmodels.PlayerViewModel
 @Composable
 fun PlayerScreen(
     streamUrl: String,
+    torrentUrl: String?,
     title: String,
     onBackClick: () -> Unit,
     viewModel: PlayerViewModel = viewModel()
@@ -33,14 +34,17 @@ fun PlayerScreen(
     val context = LocalContext.current
     val playerState by viewModel.playerState.collectAsState()
     val isFullScreen by viewModel.isFullScreen.collectAsState()
+    val torrentStats by viewModel.torrentStats.collectAsState()
+    val isTorrentStatsVisible by viewModel.isTorrentStatsVisible.collectAsState()
+    val isUsingTorrent by viewModel.isUsingTorrent.collectAsState()
     
     var showControls by remember { mutableStateOf(true) }
     var controlsTimer by remember { mutableStateOf(0) }
     
     // Initialize player
-    LaunchedEffect(Unit) {
+    LaunchedEffect(streamUrl, torrentUrl) {
         viewModel.initializePlayer()
-        viewModel.playStream(streamUrl, title)
+        viewModel.playStream(streamUrl, title, torrentUrl)
     }
     
     // Handle full screen mode
@@ -107,19 +111,33 @@ fun PlayerScreen(
                             tint = Color.White
                         )
                     }
-                    
+
                     Text(
                         text = title,
                         style = MaterialTheme.typography.titleMedium,
                         color = Color.White
                     )
-                    
-                    IconButton(onClick = { viewModel.toggleFullScreen() }) {
-                        Icon(
-                            imageVector = if (isFullScreen) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
-                            contentDescription = if (isFullScreen) "Exit Fullscreen" else "Fullscreen",
-                            tint = Color.White
-                        )
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(
+                            onClick = { viewModel.toggleTorrentStatsVisibility() },
+                            enabled = isUsingTorrent && torrentStats != null
+                        ) {
+                            val tint = if (isTorrentStatsVisible) Color.Green else Color.White
+                            Icon(
+                                imageVector = Icons.Default.Info,
+                                contentDescription = if (isTorrentStatsVisible) "Hide torrent stats" else "Show torrent stats",
+                                tint = tint
+                            )
+                        }
+
+                        IconButton(onClick = { viewModel.toggleFullScreen() }) {
+                            Icon(
+                                imageVector = if (isFullScreen) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
+                                contentDescription = if (isFullScreen) "Exit Fullscreen" else "Fullscreen",
+                                tint = Color.White
+                            )
+                        }
                     }
                 }
                 
@@ -187,7 +205,16 @@ fun PlayerScreen(
                 }
             }
         }
-        
+
+        if (isTorrentStatsVisible && torrentStats != null) {
+            TorrentStatsOverlay(
+                stats = torrentStats,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp)
+            )
+        }
+
         // Loading indicator
         if (playerState is PlayerViewModel.PlayerState.Buffering) {
             CircularProgressIndicator(
@@ -216,7 +243,7 @@ fun PlayerScreen(
                     Spacer(modifier = Modifier.height(16.dp))
                     
                     Button(
-                        onClick = { viewModel.playStream(streamUrl, title) },
+                        onClick = { viewModel.playStream(streamUrl, title, torrentUrl) },
                         colors = ButtonDefaults.buttonColors(containerColor = Color.Red)
                     ) {
                         Text("Retry")
@@ -260,4 +287,63 @@ private fun formatTime(timeMs: Long): String {
     val minutes = totalSeconds / 60
     val seconds = totalSeconds % 60
     return "%02d:%02d".format(minutes, seconds)
+}
+
+@Composable
+private fun TorrentStatsOverlay(
+    stats: PlayerViewModel.TorrentStats,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+        color = Color.Black.copy(alpha = 0.75f)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Torrent stats",
+                style = MaterialTheme.typography.titleSmall,
+                color = Color.White
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            TorrentStatRow(label = "Download", value = formatSpeed(stats.downloadSpeed))
+            TorrentStatRow(label = "Upload", value = formatSpeed(stats.uploadSpeed))
+            TorrentStatRow(label = "Peers", value = stats.peers.toString())
+            TorrentStatRow(label = "Seeds", value = stats.seeds.toString())
+
+            val progressText = "${formatPercent(stats.progress)} (${formatPercent(stats.bufferProgress)} buffered)"
+            TorrentStatRow(label = "Progress", value = progressText)
+        }
+    }
+}
+
+@Composable
+private fun TorrentStatRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = label, color = Color.White.copy(alpha = 0.8f))
+        Text(text = value, color = Color.White)
+    }
+}
+
+private fun formatSpeed(bytesPerSecond: Float): String {
+    val units = listOf("B/s", "KB/s", "MB/s", "GB/s")
+    var value = bytesPerSecond.toDouble()
+    var unitIndex = 0
+
+    while (value >= 1024 && unitIndex < units.lastIndex) {
+        value /= 1024
+        unitIndex++
+    }
+
+    return String.format("%.1f %s", value, units[unitIndex])
+}
+
+private fun formatPercent(value: Float): String {
+    val percent = if (value <= 1f) value * 100f else value
+    return String.format("%.1f%%", percent)
 }

--- a/app/src/main/java/com/secureiptv/player/ui/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/secureiptv/player/ui/viewmodels/MainViewModel.kt
@@ -3,9 +3,11 @@ package com.secureiptv.player.ui.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.secureiptv.player.data.models.Category
+import com.secureiptv.player.data.models.Episode
 import com.secureiptv.player.data.models.LiveStream
 import com.secureiptv.player.data.models.Movie
 import com.secureiptv.player.data.models.Series
+import com.secureiptv.player.data.models.StreamSource
 import com.secureiptv.player.data.repository.IPTVRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -234,19 +236,43 @@ class MainViewModel : ViewModel() {
     fun getLiveStreamUrl(streamId: Int): String {
         return repository.buildLiveStreamUrl(streamId)
     }
-    
+
+    /**
+     * Builds the available sources for a live stream
+     */
+    fun getLiveStreamSource(stream: LiveStream): StreamSource {
+        val httpUrl = getLiveStreamUrl(stream.streamId)
+        return buildStreamSource(httpUrl, stream.directSource)
+    }
+
     /**
      * Gets a VOD stream URL
      */
     fun getVodStreamUrl(streamId: Int): String {
         return repository.buildVodStreamUrl(streamId)
     }
-    
+
+    /**
+     * Builds the available sources for a movie
+     */
+    fun getVodStreamSource(movie: Movie): StreamSource {
+        val httpUrl = getVodStreamUrl(movie.streamId)
+        return buildStreamSource(httpUrl, movie.directSource)
+    }
+
     /**
      * Gets a series stream URL
      */
     fun getSeriesStreamUrl(streamId: Int): String {
         return repository.buildSeriesStreamUrl(streamId)
+    }
+
+    /**
+     * Builds the available sources for an episode
+     */
+    fun getSeriesStreamSource(episode: Episode): StreamSource {
+        val httpUrl = getSeriesStreamUrl(episode.id)
+        return buildStreamSource(httpUrl, episode.directSource)
     }
     
     /**
@@ -323,5 +349,26 @@ class MainViewModel : ViewModel() {
      */
     enum class ItemType {
         LIVE, VOD, SERIES
+    }
+
+    private fun buildStreamSource(httpUrl: String, directSource: String?): StreamSource {
+        return StreamSource(
+            httpUrl = httpUrl,
+            torrentUrl = extractTorrentUrl(directSource)
+        )
+    }
+
+    private fun extractTorrentUrl(directSource: String?): String? {
+        val value = directSource?.trim().orEmpty()
+        if (value.isEmpty()) {
+            return null
+        }
+
+        val lower = value.lowercase()
+        return if (lower.startsWith("magnet:") || lower.endsWith(".torrent")) {
+            value
+        } else {
+            null
+        }
     }
 }

--- a/app/src/main/java/com/secureiptv/player/ui/viewmodels/PlayerViewModel.kt
+++ b/app/src/main/java/com/secureiptv/player/ui/viewmodels/PlayerViewModel.kt
@@ -1,6 +1,12 @@
 package com.secureiptv.player.ui.viewmodels
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
+import com.github.se_bastiaan.torrentstream.StreamStatus
+import com.github.se_bastiaan.torrentstream.Torrent
+import com.github.se_bastiaan.torrentstream.TorrentOptions
+import com.github.se_bastiaan.torrentstream.TorrentStream
+import com.github.se_bastiaan.torrentstream.listeners.TorrentListener
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
@@ -8,6 +14,7 @@ import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.util.MimeTypes
 import com.secureiptv.player.IPTVApplication
+import java.io.File
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -22,9 +29,77 @@ class PlayerViewModel : ViewModel() {
     
     private val _playerState = MutableStateFlow<PlayerState>(PlayerState.Idle)
     val playerState: StateFlow<PlayerState> = _playerState.asStateFlow()
-    
+
     private val _isFullScreen = MutableStateFlow(false)
     val isFullScreen: StateFlow<Boolean> = _isFullScreen.asStateFlow()
+
+    private val _torrentStats = MutableStateFlow<TorrentStats?>(null)
+    val torrentStats: StateFlow<TorrentStats?> = _torrentStats.asStateFlow()
+
+    private val _isTorrentStatsVisible = MutableStateFlow(false)
+    val isTorrentStatsVisible: StateFlow<Boolean> = _isTorrentStatsVisible.asStateFlow()
+
+    private val _isUsingTorrent = MutableStateFlow(false)
+    val isUsingTorrent: StateFlow<Boolean> = _isUsingTorrent.asStateFlow()
+
+    private var currentHttpUrl: String? = null
+    private var currentSubtitleUrl: String? = null
+    private var currentTitle: String? = null
+
+    private var torrentStream: TorrentStream? = null
+    private var torrentListenerRegistered = false
+
+    private val torrentListener = object : TorrentListener {
+        override fun onStreamPrepared(torrent: Torrent?) {
+            torrent?.videoFile?.let { file ->
+                val title = currentTitle ?: file.name
+                val mediaMetadata = com.google.android.exoplayer2.MediaMetadata.Builder()
+                    .setTitle(title)
+                    .build()
+
+                val mediaItem = MediaItem.Builder()
+                    .setUri(Uri.fromFile(file))
+                    .setMediaMetadata(mediaMetadata)
+                    .build()
+
+                player?.stop()
+                player?.setMediaItem(mediaItem)
+                player?.prepare()
+                player?.play()
+            }
+        }
+
+        override fun onStreamStarted(torrent: Torrent?) {
+            _playerState.value = PlayerState.Buffering
+        }
+
+        override fun onStreamProgress(torrent: Torrent?, status: StreamStatus?) {
+            if (status != null) {
+                _torrentStats.value = TorrentStats(
+                    progress = status.progress.toFloat(),
+                    bufferProgress = status.bufferProgress.toFloat(),
+                    downloadSpeed = status.downloadSpeed.toFloat(),
+                    uploadSpeed = status.uploadSpeed.toFloat(),
+                    seeds = status.seeds,
+                    peers = status.peers
+                )
+            }
+        }
+
+        override fun onStreamReady(torrent: Torrent?) {
+            _playerState.value = PlayerState.Playing
+        }
+
+        override fun onStreamStopped() {
+            _torrentStats.value = null
+            _isUsingTorrent.value = false
+            _isTorrentStatsVisible.value = false
+        }
+
+        override fun onStreamError(torrent: Torrent?, e: Exception?) {
+            handleTorrentError(e)
+        }
+    }
     
     /**
      * Initializes the player
@@ -61,18 +136,79 @@ class PlayerViewModel : ViewModel() {
     }
     
     /**
-     * Plays a stream URL
+     * Plays a stream URL, optionally using a torrent source.
      */
-    fun playStream(url: String, title: String, subtitleUrl: String? = null) {
+    fun playStream(
+        url: String,
+        title: String,
+        torrentUrl: String? = null,
+        subtitleUrl: String? = null
+    ) {
         initializePlayer()
-        
-        val mediaItem = if (subtitleUrl != null) {
-            val subtitleConfig = MediaItem.SubtitleConfiguration.Builder(android.net.Uri.parse(subtitleUrl))
+        currentHttpUrl = url
+        currentSubtitleUrl = subtitleUrl
+        currentTitle = title
+        _isTorrentStatsVisible.value = false
+
+        if (!torrentUrl.isNullOrBlank()) {
+            startTorrentStream(torrentUrl)
+        } else {
+            playHttpStream(url, title, subtitleUrl)
+        }
+    }
+
+    private fun startTorrentStream(torrentUrl: String) {
+        stopTorrentStream()
+        val stream = ensureTorrentStream()
+        _isUsingTorrent.value = true
+        _playerState.value = PlayerState.Buffering
+        stream.startStream(torrentUrl)
+    }
+
+    private fun ensureTorrentStream(): TorrentStream {
+        if (torrentStream == null) {
+            torrentStream = try {
+                TorrentStream.getInstance()
+            } catch (e: IllegalStateException) {
+                null
+            }
+
+            if (torrentStream == null) {
+                val context = IPTVApplication.instance
+                val torrentDir = File(context.cacheDir, "torrent_streams").apply {
+                    if (!exists()) {
+                        mkdirs()
+                    }
+                }
+
+                val options = TorrentOptions.Builder()
+                    .saveLocation(torrentDir)
+                    .removeFilesAfterStop(true)
+                    .build()
+
+                torrentStream = TorrentStream.init(options)
+            }
+        }
+
+        if (!torrentListenerRegistered) {
+            torrentStream?.addListener(torrentListener)
+            torrentListenerRegistered = true
+        }
+
+        return torrentStream!!
+    }
+
+    private fun playHttpStream(url: String, title: String, subtitleUrl: String?) {
+        stopTorrentStream()
+        _isUsingTorrent.value = false
+
+        val mediaItem = if (!subtitleUrl.isNullOrBlank()) {
+            val subtitleConfig = MediaItem.SubtitleConfiguration.Builder(Uri.parse(subtitleUrl))
                 .setMimeType(MimeTypes.APPLICATION_SUBRIP)
                 .setLanguage("en")
                 .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
                 .build()
-                
+
             MediaItem.Builder()
                 .setUri(url)
                 .setMediaMetadata(
@@ -92,10 +228,49 @@ class PlayerViewModel : ViewModel() {
                 )
                 .build()
         }
-        
+
+        player?.stop()
         player?.setMediaItem(mediaItem)
         player?.prepare()
         player?.play()
+    }
+
+    private fun handleTorrentError(error: Exception?) {
+        val fallbackUrl = currentHttpUrl
+        val title = currentTitle ?: ""
+
+        if (fallbackUrl != null) {
+            _playerState.value = PlayerState.Buffering
+            playHttpStream(fallbackUrl, title, currentSubtitleUrl)
+        } else {
+            _playerState.value = PlayerState.Error(error?.message ?: "Playback error")
+        }
+    }
+
+    private fun stopTorrentStream() {
+        torrentStream?.let { stream ->
+            try {
+                stream.stopStream()
+            } catch (_: Exception) {
+                // Ignored – stopping is best effort
+            }
+
+            if (torrentListenerRegistered) {
+                stream.removeListener(torrentListener)
+                torrentListenerRegistered = false
+            }
+        }
+
+        torrentStream = null
+        _torrentStats.value = null
+        _isTorrentStatsVisible.value = false
+        _isUsingTorrent.value = false
+    }
+
+    fun toggleTorrentStatsVisibility() {
+        if (_torrentStats.value != null) {
+            _isTorrentStatsVisible.value = !_isTorrentStatsVisible.value
+        }
     }
     
     /**
@@ -129,6 +304,7 @@ class PlayerViewModel : ViewModel() {
      * Releases the player
      */
     fun releasePlayer() {
+        stopTorrentStream()
         player?.release()
         player = null
         _playerState.value = PlayerState.Idle
@@ -159,7 +335,19 @@ class PlayerViewModel : ViewModel() {
         super.onCleared()
         releasePlayer()
     }
-    
+
+    /**
+     * Snapshot of the current torrent streaming stats
+     */
+    data class TorrentStats(
+        val progress: Float,
+        val bufferProgress: Float,
+        val downloadSpeed: Float,
+        val uploadSpeed: Float,
+        val seeds: Int,
+        val peers: Int
+    )
+
     /**
      * Represents the state of the player
      */

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
@@ -28,6 +29,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
## Summary
- add the TorrentStream Android dependency and JitPack repository so the app can stream over BitTorrent
- surface optional torrent sources alongside HTTP URLs when navigating to the player screen
- wire the TorrentStream engine into `PlayerViewModel` with a toggleable stats overlay that shows peers and transfer rates in `PlayerScreen`

## Testing
- `./gradlew assembleDebug` *(not run: the checked-in `gradlew` script is empty, so the Gradle wrapper cannot build the project in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06bc396f8832f81947751550ba005